### PR TITLE
improve to support bundles managed by other add-on managers

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -28,6 +28,9 @@
 command! -nargs=+ NeoBundle
       \ call neobundle#config#bundle(<args>)
 
+command! -nargs=+ NeoExternalBundle
+      \ call neobundle#config#external_bundle(<args>)
+
 command! -nargs=? -bang NeoBundleInstall
       \ call neobundle#installer#install('!' == '<bang>', <q-args>)
 

--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -85,6 +85,14 @@ function! neobundle#config#bundle(arg, ...)
   call s:rtp_add(path)
 endfunction
 
+function! neobundle#config#external_bundle(arg, ...)
+  let bundle = neobundle#config#init_bundle(a:arg, a:000)
+  let path = bundle.path
+  if !has_key(s:neobundles, path)
+    let s:neobundles[path] = bundle
+  endif
+endfunction
+
 function! neobundle#config#rm_bndle(path)
   if has_key(s:neobundles, a:path)
     call s:rtp_rm(s:neobundles[a:path].path)


### PR DESCRIPTION
add a simple command `NeoExternalBundle` to let neobundle to manage bundles managed by other add-on managers like vundle, vim-addon-manager, etc. The reason for that is to be able to use unite to mange the bundles...

Personally, this is useful because `vim-addon-manager` can load bundles on-demand at runtime. Therefore, i can group bundles into groups of flavors like dev-perl, dev-c, dev-vim, ... and load then using `FileType` autocmd or do it manually. 
