### PR TITLE
Added rtp option.

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -79,11 +79,11 @@ function! neobundle#config#bundle(arg, ...)
   let bundle = neobundle#config#init_bundle(a:arg, a:000)
   let path = bundle.path
   if has_key(s:neobundles, path)
-    call s:rtp_rm(path)
+    call s:rtp_rm(bundle.rtp)
   endif
 
   let s:neobundles[path] = bundle
-  call s:rtp_add(path)
+  call s:rtp_add(bundle.rtp)
   return bundle
 endfunction
 
@@ -98,7 +98,7 @@ endfunction
 
 function! neobundle#config#rm_bndle(path)
   if has_key(s:neobundles, a:path)
-    call s:rtp_rm(s:neobundles[a:path].path)
+    call s:rtp_rm(s:neobundles[a:path].rtp)
     call remove(s:neobundles, a:path)
   endif
 endfunction
@@ -122,6 +122,7 @@ function! neobundle#config#init_bundle(name, opts)
         \ s:parse_options(a:opts))
   let bundle.path = s:expand_path(neobundle#get_neobundle_dir().'/'.
         \ get(bundle, 'directory', bundle.name))
+  let bundle.rtp = s:expand_path(bundle.path.'/'.get(bundle, 'rtp', '').'/')
   let bundle.orig_name = a:name
   let bundle.orig_opts = a:opts
 

--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -73,9 +73,9 @@ function! neobundle#installer#helptags(bundles)
     return
   endif
 
-  let help_dirs = filter(copy(a:bundles), 's:has_doc(v:val.path)')
+  let help_dirs = filter(copy(a:bundles), 's:has_doc(v:val.rtp)')
 
-  call map(help_dirs, 's:helptags(v:val.path)')
+  call map(help_dirs, 's:helptags(v:val.rtp)')
   if !empty(help_dirs)
     call neobundle#installer#log('Helptags: done. '
           \ .len(help_dirs).' bundles processed')

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -110,6 +110,9 @@ COMMANDS 					*neobundle-commands*
 		Repository type.
 		For example: nosync, git, svn, hg, ...
 
+		rtp		(String)
+		Runtimepath.
+
 		Examples:
 >
 		NeoBundle 'git_repository_uri'
@@ -120,6 +123,7 @@ COMMANDS 					*neobundle-commands*
 		NeoBundle 'https://bitbucket.org/ns9tks/vim-fuzzyfinder'
 		NeoBundle 'git://github.com/Shougo/unite.vim.git', {'directory' : 'unite'}
 		NeoBundle 'git://host/path/repo.git', {'type': 'hg'}
+		NeoBundle 'rstacruz/sparkup', {'rtp': 'vim/'}
 <
 		This supports revision lock.
 		Note: It's manual to restore its revision. Or, set to revision


### PR DESCRIPTION
リポジトリのサブディレクトリをruntimepathにするrtpオプションを追加しました。
READMEの`NeoBundle 'rstacruz/sparkup', {'rtp': 'vim/'}`のように設定します。
