### PR TITLE
- Fixed :NeoBundleInstall bug.

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -1,7 +1,7 @@
 "=============================================================================
 " FILE: config.vim
 " AUTHOR:  Shougo Matsushita <Shougo.Matsu at gmail.com>
-" Last Modified: 11 Jan 2012.
+" Last Modified: 24 Feb 2012.
 " License: MIT license  {{{
 "     Permission is hereby granted, free of charge, to any person obtaining
 "     a copy of this software and associated documentation files (the
@@ -53,8 +53,8 @@ function! neobundle#config#reload(bundles)
     endif
   endfor
 
-  silent! runtime! plugin/**.vim
-  silent! runtime! after/plugin/**.vim
+  silent! runtime! plugin/**/*.vim
+  silent! runtime! after/plugin/**/*.vim
 
   " Reload autoload scripts.
   let scripts = []

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -254,6 +254,9 @@ neobundle					*unite-action-neobundle*
 ==============================================================================
 CHANGELOG					*neobundle-changelog*
 
+2012-02-24
+- Fixed :NeoBundleInstall bug.
+
 2012-02-16
 - Fixed neobundle initialization.
 


### PR DESCRIPTION
Hi.

If a plugin has a directory named `*.vim/` in its `plugin/` directory, reloading the plugins at the end of `:NeoBundleInstall` will cause errors.

See the [Hammer](https://github.com/robgleeson/hammer.vim) plugin, for example. All the files inside `plugin/hammer.vim/` are sourced, including a lot of Ruby scripts.

I have changed the runtime lines to source only `*.vim` files.

Cheers.
