### PR TITLE
fixed README for enable filetype detect.

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ NeoBundle is Vim plugin manager based on Vundle(https://github.com/gmarik/vundle
 
      ```vim
      set nocompatible               " be iMproved
-     filetype plugin indent off     " required!
+     filetype off     " required!
 
      if has('vim_starting')
        set runtimepath+=~/.vim/bundle/neobundle.vim/


### PR DESCRIPTION
filetype plugin indent off では detect が無効にならず、
管理しているプラグインの ftdetect が有効にならないようです。
filetype off に変更することで ftdetect が動作しました。

動作しているかどうかは vim-scala を利用時にscalaファイルを開いたときのハイライトの有無で判断しました。 

OS: Windows XP SP3 32bit
Vim: gvim (vim73-kaoriya-win32-20120407)
NeoBundle: - Added base attribute. commit 56b3756e617df5e6441afca0ec143a4dafb1a730
TestPlugin: ujihisa / vim-scala Giving a way to disable default key mappings, preserving backward-com… commit 292ddbbf62b842cd21d11b3a792480329365dc18
.vimrc:
set nocompatible               " be iMproved
" filetype plugin indent off     " required!
filetype off     " required!
if has('vim_starting')
  set runtimepath+=~/.vim/bundle/neobundle.vim/
  call neobundle#rc(expand('~/.vim/bundle/'))
  let g:neobundle_default_git_protocol = "git+https"
endif
NeoBundle 'ujihisa/vim-scala.git', {'type': 'hg'}
filetype plugin indent on     " required!

TestFile: Hello.scala
object Hello {
  def main(args: Array[String]) {
    println("Hello")
  }
}
