### PR TITLE
- Fixed :NeoBundleClean helptag.

### DIFF
--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -208,7 +208,7 @@ COMMANDS 					*neobundle-commands*
 :NeoBundleUpdate [{name}]			*:NeoBundleUpdate*
 		Same to |:NeoBundleInstall!|.
 
-:NeoBundleClean [{bang} [{name}...]] 	*:NeoBundleWithCurrentDir*
+:NeoBundleClean [{bang} [{name}...]] 	*:NeoBundleClean*
 		Removes non configured plugins. If {bang} is added, force
 		remove plugins. If {name} are added, remove
 		{name} plugins.


### PR DESCRIPTION
ヘルプの :NeoBundleClean についているタグを編集しました。

変更後は、g:neobundle_rm_command のヘルプ中の |:NeoBundleClean| からジャンプできることを確認しました。
