### PR TITLE
:Unite neobundle:{bundle_name} を使えるように

### DIFF
--- a/autoload/unite/sources/neobundle.vim
+++ b/autoload/unite/sources/neobundle.vim
@@ -68,7 +68,7 @@ let s:source.filters =
 "}}}
 
 function! s:source.gather_candidates(args, context)"{{{
-  let _ = map(neobundle#config#get_neobundles(), "{
+  let _ = map(a:context.source__bundles, "{
         \ 'word' : substitute(v:val.orig_name,
         \  '^\%(https\?\|git\)://\%(github.com/\)\?', '', ''),
         \ 'kind' : 'neobundle',


### PR DESCRIPTION
unite/sources/neobundle.vim のソースを見ると、uniteの引数として渡された '!' 以外の文字列をbundle名として扱っているようですが、gather_candidatesの方では利用されていません。なのでそれを利用するようにしました。
引数の使用目的が間違っていたらすみません。
