### PR TITLE
Fixes #46 - Adds option 'clear_log'

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -45,6 +45,8 @@ endif
 call neobundle#util#set_default(
       \ 'g:neobundle#log_filename', '', 'g:neobundle_log_filename')
 call neobundle#util#set_default(
+      \ 'g:neobundle#clear_log', 1, 'g:neobundle_clear_log')
+call neobundle#util#set_default(
       \ 'g:neobundle#default_site', 'github', 'g:neobundle_default_site')
 call neobundle#util#set_default(
       \ 'g:neobundle#enable_tail_path', 1, 'g:neobundle_enable_tail_path')

--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -65,7 +65,9 @@ function! neobundle#installer#install(bang, bundle_names)
     return
   endif
 
-  call neobundle#installer#clear_log()
+  if g:neobundle#clear_log == 1
+    call neobundle#installer#clear_log()
+  endif
   let [installed, errored] = s:install(a:bang, bundles)
   if !has('vim_starting')
     redraw!

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -567,6 +567,12 @@ g:neobundle#log_filename			*g:neobundle#log_filename*
 
 		Default value is "".
 
+g:neobundle#clear_log                           *g:neobundle#clear_log*
+		If it is 1, the log set in |g:neobundle#log_filename| is cleared
+		on each install and update of plugins.
+
+		Default value is 1.
+
 g:neobundle#enable_tail_path			*g:neobundle#enable_tail_path*
 		If it is 1, default "tail_path" attribute will be 1 in bundle.
 


### PR DESCRIPTION
`1` clears log file on instal/update, the default (overwriting the log file)
`0` does not clear the log file on install/update (appending to the log file)

My .vimrc looks like this:

```
let g:neobundle#log_filename=expand('~/.vim/plugin_install.log')
let g:neobundle#clear_log=0
```

This allows me to keep my install log under version control [like so](https://github.com/stephenmckinney/vimfiles/blob/master/vim/plugin_install.log)
