### PR TITLE
Do not append --depth option when the revision is specified

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -107,6 +107,7 @@ function! s:type.get_sync_command(bundle) "{{{
     let cmd = 'git clone'
 
     if get(a:bundle, 'type__shallow', 1)
+          \ && get(a:bundle, 'rev', '') ==# ''
           \ && a:bundle.uri !~ '^git@github\.com:'
       " Use shallow clone.
       let cmd .= ' --depth 1'


### PR DESCRIPTION
Shallow clone may not contain specified revision because it is older

(with Git)
