### PR TITLE
Specify 'type' doesn't work when install bundle from a git repository

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -74,6 +74,7 @@ function! s:type.detect(path, opts) "{{{
     endif
   elseif a:path =~# '\<\%(git@\|git://\)\S\+'
         \ || a:path =~# '\.git\s*$'
+        \ || get(a:opts, 'type') ==# 'git'
     if a:path =~# '\<\%(bb\|bitbucket\):\S\+'
       let name = substitute(split(a:path, ':')[-1],
             \   '^//bitbucket.org/', '', '')


### PR DESCRIPTION
We have an internal git repository in our company. And the repo path doesn't suffixed by  '.git'.
My bundles.vim is as below

<pre>
NeoBundle 'user@git-host:/the/path/of/repo', { 'type' : 'git' }
</pre>


But the installation failed.

I have digged around. It seems when install a new bundle, the option 'type' doesn't actually help to generate the bundle.uri. The bundle.uri always detect from the repo path. And in autoload/neobunde/types/git.vim, the detecting regex only supports the repo path with the suffix '.git'. So my repo is not detected, and the bundle.uri is empty.

I am a newbee at vim script. So I don't know if my patch is perfect.
