### PR TITLE
Fixed neobundle/search.

### DIFF
--- a/autoload/neobundle/sources/github.vim
+++ b/autoload/neobundle/sources/github.vim
@@ -61,8 +61,8 @@ endfunction"}}}
 " Misc.
 function! s:get_github_searches(string) "{{{
   let path = 'https://api.github.com/legacy/repos/search/'
-        \ . a:string . '?language=VimL'
-  let temp = tempname()
+        \ . a:string . '*?language=VimL'
+  let temp = unite#util#substitute_path_separator(tempname())
 
   let cmd = printf('%s "%s" "%s"', (executable('curl') ?
           \ 'curl --fail -s -o' : 'wget -q -O '), temp, path)

--- a/autoload/neobundle/sources/vim_scripts_org.vim
+++ b/autoload/neobundle/sources/vim_scripts_org.vim
@@ -94,7 +94,7 @@ function! s:get_repository_plugins(context, path) "{{{
       call delete(cache_path)
     endif
 
-    let temp = tempname()
+    let temp = unite#util#substitute_path_separator(tempname())
 
     if executable('curl')
       let cmd = 'curl --fail -s -o "' . temp . '" '. a:path


### PR DESCRIPTION
github から検索する際の URI が動作していなかったので修正しました。
参照：http://lingr.com/room/vim/archives/2013/02/26#message-14135818

あと出力ファイルのパス区切りが \ では出力されなかったので / に変更する処理も追加しました。
