### PR TITLE
NeoBundleCleanの際にscript_type指定したbundleも候補に挙がってしまう

### DIFF
--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -209,7 +209,8 @@ function! s:build_vimproc_dll(cmd)
 endfunction
 
 function! neobundle#installer#clean(bang, ...)
-  let bundle_dirs = map(copy(neobundle#config#get_neobundles()), 'v:val.path')
+  let bundle_dirs = map(copy(neobundle#config#get_neobundles()), 'v:val.script_type != "" ?
+        \ v:val.base . "/" . v:val.directory : v:val.path')
   let all_dirs = split(neobundle#util#substitute_path_separator(
         \ globpath(neobundle#get_neobundle_dir(), '*')), "\n")
   if get(a:000, 0, '') == ''


### PR DESCRIPTION
``` vim
:NeoBundle 'https://gist.github.com/****.git', {
  \ 'name' : 'test',
  \ 'script_type' : 'plugin'}
:NeoBundleInstall
:NeoBundleClean
> ****/.vim/bundle/test
> Are you sure you want to remove 1 bundles? [y/n] :     
```

全て `v:val.base . "/" . v:val.directory` でも問題ない気はしなくも無いのですが、念の為 `script_type` 指定された時のみにしています
(巨大且つ機能豊富なのでどんなケースがあるか把握できてないです)

---

結局の所 `v:val.path` に `script_type` 別のディレクトリも含まれているのが問題なだけなのでスライス等、他にも方法は色々ありますね
