### PR TITLE
Recursively initialise/update submodules

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -102,11 +102,11 @@ function! s:type.get_sync_command(bundle) "{{{
   endif
 
   if !isdirectory(a:bundle.path)
-    let cmd = 'git clone'
+    let cmd = 'git clone --recursive'
 
     let cmd .= printf(' %s "%s"', a:bundle.uri, a:bundle.path)
   else
-    let cmd = 'git pull --rebase'
+    let cmd = 'git pull --rebase && git submodule update --init --recursive'
   endif
 
   return cmd


### PR DESCRIPTION
Git submodules should be recursively initialised/updated when cloning or updating a bundle.
