### PR TITLE
`Unite source` の際にautoload/unite_sources指定した物が候補に挙がらない

### DIFF
--- a/autoload/neobundle/autoload.vim
+++ b/autoload/neobundle/autoload.vim
@@ -118,9 +118,13 @@ function! neobundle#autoload#unite_sources(sources)
   let sources_bundles = filter(neobundle#config#get_autoload_bundles(),
           \ "has_key(v:val.autoload, 'unite_sources')")
   for source_name in a:sources
-    let bundles += filter(copy(sources_bundles),
-          \ "index(neobundle#util#convert2list(
-          \    v:val.autoload.unite_sources), source_name) >= 0")
+    if source_name == 'source'
+      let bundles += copy(sources_bundles)
+    else
+      let bundles += filter(copy(sources_bundles),
+            \ "index(neobundle#util#convert2list(
+            \    v:val.autoload.unite_sources), source_name) >= 0")
+    endif
   endfor
 
   call neobundle#config#source_bundles(neobundle#util#uniq(bundles))


### PR DESCRIPTION
タイトルの通りです。

---

大量に入れてるとそれなりに固まるんで読み込み中メッセージを出してみたりもしましたが、
これはこれでautoloadまみれだとチラついてウザい感があって微妙っぽい:sweat:
DeaR@d3b013b3da19311146b911b58d25eb5ffe47292a
DeaR@b6d208572b67a51d6cfadc72857a0c3ade88da8a
