### PR TITLE
Installation stops too early when vimproc is not used.

### DIFF
--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -619,16 +619,14 @@ function! s:install(bang, bundles)
         \ len(context.source__bundles)
 
   while 1
-    if context.source__number < context.source__max_bundles
-      while context.source__number < context.source__max_bundles
-            \ && len(context.source__processes) <
-            \      g:neobundle#install_max_processes
+    while context.source__number < context.source__max_bundles
+          \ && len(context.source__processes) <
+          \      g:neobundle#install_max_processes
 
-        call neobundle#installer#sync(
-              \ context.source__bundles[context.source__number],
-              \ context, 0)
-      endwhile
-    endif
+      call neobundle#installer#sync(
+            \ context.source__bundles[context.source__number],
+            \ context, 0)
+    endwhile
 
     for process in context.source__processes
       call neobundle#installer#check_output(context, process, 0)


### PR DESCRIPTION
After 436e4d4c5fff7023e95d93886724adfb690f3425, the loop exit condition in `s:install()` is always true when vimproc is not used. As a result, installation will always stop after `g:neobundle#install_max_processes` bundles have been installed, even if there are still more bundles to install. I think this can also happen if, when using vimproc, all spawned processes happen to finish at the same time.
