### PR TITLE
Fix E121: Undefined variable: filetype_out

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -269,6 +269,7 @@ function! neobundle#config#source(names, ...)
     return
   endif
 
+  let filetype_out = ''
   redir => filetype_out
   silent filetype
   redir END


### PR DESCRIPTION
this assignment should be unnecessary. But somehow this error happens when I launch a new vim from terminal with -c `Gdiff` (vim-fugitive).

``` vim
Error detected while processing function neobundle#autoload#command..neobundle#config#source:
line   22:
E121: Undefined variable: filetype_out
```
