### PR TITLE
Add gist to sites.

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -56,6 +56,16 @@ function! s:type.detect(path, opts) "{{{
     " Local repository.
     return { 'name' : split(a:path, '/')[-1],
           \  'uri' : a:path, 'type' : 'git' }
+  elseif a:path =~# '\<gist:\S\+\|://gist.github.com/'
+    let name = split(a:path, ':')[-1]
+    let uri =  (protocol ==# 'ssh') ?
+          \ 'git@gist.github.com:' . split(name, '/')[-1] :
+          \ protocol . '://gist.github.com/'. split(name, '/')[-1]
+
+    if uri !~ '\.git\s*$'
+      " Add .git suffix.
+      let uri .= '.git'
+    endif
   elseif a:path =~# '\<\%(gh\|github\):\S\+\|://github.com/'
     if a:path =~ '/'
       let name = substitute(split(a:path, ':')[-1],

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -522,6 +522,7 @@ OPTIONS 					*neobundle-options*
 		Available sites:
 		"github" or "gh"    : github.com (git)
 		"bitbucket" or "bb" : bitbucket.org (hg)
+		"gist"              : gist.github.com (git)
 
 						*neobundle-options-rtp*
 		rtp			(String)
@@ -862,6 +863,14 @@ OPTIONS 					*neobundle-options*
 		" For raw repository.
 		NeoBundle 'https://raw.github.com/m2ym/rsense/master/etc/rsense.vim',
 		      \ {'script_type' : 'plugin'}
+
+		" For gist repository.
+		NeoBundle 'gist:Shougo/656148', {
+		      \ 'name': 'everything.vim',
+		      \ 'script_type': 'plugin'}
+		NeoBundle 'gist:355360', {
+		      \ 'name': 'ambicmd.vim',
+		      \ 'script_type': 'plugin'}
 <
 		Neobundle supports revision (or branch) lock.
 		Note: The revision (or branch) is checked out in


### PR DESCRIPTION
表題の通り `bitbucket:xxx/xxx` のように 'gist:xxx/xxx' を加える修正です
docのexampleはShougoさんのgistから適当に持ってきました(自分のを書くのもアレだったので)

主な利点
- `htpps://gist.github.com/xxx.git` より短く表記ができる
- `g:neobundle#types#git#default_protocol` に依存できる(ページにはhttpsしか書いていないが他も使用できる)

---

どうもうちのandroidのgitが `git@` しか動作しなくて、
他環境ではパスフレーズはいってるから `git://` を使いたい故に作成:sweat_smile:
今の所は↓みたいにやって何とか回避させてる感じです

``` vim
let s:is_android = has('unix') &&
  \ ($HOSTNAME ==? 'android' ||
  \  $VIM =~? 'net\.momodalo\.app\.vimtouch' ||
  \  $VIM =~? 'com\.spartacusrex\.spartacuside')

execute join(["NeoBundleLazy '",
  \ s:is_android ?
  \   'git@gist.github.com:5558981.git' :
  \   'git://gist.github.com/5558981.git',
  \ "', {",
  \   "'name' : 'maplist.vim',",
  \   "'autoload' : {",
  \     "'commands' : [",
  \       "'MapList',  'NMapList', 'VMapList', 'OMapList', 'XMapList',",
  \       "'SMapList', 'IMapList', 'CMapList', 'LMapList']},",
  \   "'script_type' : 'plugin'}"], '')
```
