### PR TITLE
add a:bundle.installed_uri

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -112,7 +112,7 @@ function! s:type.get_sync_command(bundle) "{{{
 
     let cmd .= printf(' %s "%s"', a:bundle.uri, a:bundle.path)
   else
-    let cmd = 'git pull --rebase && git submodule update --init --recursive'
+    let cmd = 'git pull --rebase ' . a:bundle.installed_uri . ' && git submodule update --init --recursive'
   endif
 
   return cmd


### PR DESCRIPTION
`.git/config`のurlを書き換えてしまうと、現状、場合によってはsshプロセスが止まってしまうので、git pull 時にも明示的にurlを指定したほうがいいと思うのですがどうでしょうか？
