### PR TITLE
NeoBundleInstall,NeoBundleUpdate時にon_sourceが呼ばれない等

### DIFF
--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -106,7 +106,8 @@ endfunction
 function! neobundle#installer#update(bundles)
   call neobundle#installer#helptags(
         \ neobundle#config#get_neobundles())
-  call s:reload(a:bundles)
+  call s:reload(filter(copy(a:bundles),
+        \ 'v:val.sourced && !v:val.disabled'))
 
   call s:save_install_info(neobundle#config#get_neobundles())
 endfunction
@@ -889,6 +890,9 @@ function! s:reload(bundles) "{{{
     endif
   endfor
 
+  " Call hooks.
+  call neobundle#call_hook('on_source', a:bundles)
+
   silent! runtime! ftdetect/**/*.vim
   silent! runtime! after/ftdetect/**/*.vim
   silent! runtime! plugin/**/*.vim
@@ -913,7 +917,6 @@ function! s:reload(bundles) "{{{
   endfor
 
   " Call hooks.
-  call neobundle#call_hook('on_source', a:bundles)
   call neobundle#call_hook('on_post_source', a:bundles)
 endfunction"}}}
 


### PR DESCRIPTION
- `on_source`の呼び出しタイミングが`runtime`の後になっていたので移動
- `disabled=1`でも呼び込まれてしまうのでfilter
- `sourced=0`の物は再読込を行わないように修正
