### PR TITLE
Fix define dummy mappings.

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -465,14 +465,14 @@ function! neobundle#config#add(bundle, ...) "{{{
     for item in neobundle#util#convert2list(
           \ get(bundle.autoload, 'mappings', []))
       if type(item) == type([])
-        let [mode, mappings] = [item[0], item[1:]]
+        let [modes, mappings] = [item[0], item[1:]]
       else
-        let [mode, mappings] = ['nxo', [item]]
+        let [modes, mappings] = ['nxo', [item]]
       endif
 
       for mapping in mappings
         " Define dummy mappings.
-        for mode in filter(split(mode, '\zs'),
+        for mode in filter(split(modes, '\zs'),
               \ "index(['n', 'v', 'x', 'o', 'i'], v:val) >= 0")
           silent! execute mode.'noremap <unique><silent>' mapping printf(
                 \ (mode ==# 'i' ? "\<C-o>:" : ":\<C-u>").


### PR DESCRIPTION
``` vim
" Sample
NeoBundleLazy 'kana/vim-textobj-entire', {
  \ 'autoload' : {
  \   'mappings' : [
  \     ['vo',
  \      '<Plug>(textobj-entire-a)',
  \      '<Plug>(textobj-entire-i)']]},
  \ 'depends' : 'kana/vim-textobj-user'}
```

``` vim
:map
o  <Plug>(textobj-entire-i) * :<C-U>call neobundle#autoload#mapping('<Plug>(textobj-entire-i)', 'textobj-entire', 'o')
o  <Plug>(textobj-entire-a) * :<C-U>call neobundle#autoload#mapping('<Plug>(textobj-entire-a)', 'textobj-entire', 'o')
x  <Plug>(textobj-entire-a) * :<C-U>call neobundle#autoload#mapping('<Plug>(textobj-entire-a)', 'textobj-entire', 'x')
```

`mode`をそのまま使用していた為に`{mapping2}`以降で`{mode}`の最後の1つしか定義されなかったので修正しました
