### PR TITLE
Check for :NeoBundleDepends explicitly

### DIFF
--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -332,7 +332,7 @@ COMMANDS 					*neobundle-commands*
 		Note: This command does not overwrite user neobundle
 		configuration.
 >
-		if exists(':NeoBundleDepends')
+		if exists(':NeoBundleDepends') == 2
 		  NeoBundleDepends 'Shougo/unite.vim.git'
 		endif
 <


### PR DESCRIPTION
`neobundle.txt` has this example:

```
if exists(':NeoBundleDepends')
  NeoBundleDepends 'Shougo/unite.vim.git'
endif
```

But the documentation for `exists()` says

> To check for a supported command always check the return value to be 2.

This could be a problem (at least in theory): for example, if in the future the interface changes and there are two commands `:NeoBundleDependsStrict` and `:NeoBundleDependsLazy`, the test will still be true, and any one of the commands will be executed. So I think it's better to be explicit, as in the attached pull request.

---

By the way, Shougo, what is the recommended way to declare dependencies in a plugin? Is it better to use `:NeoBundleDepends` or a neobundle recipe? I did it [like this](https://github.com/glts/vim-textobj-comment/blob/master/plugin/textobj/comment.vim#L12-L14). Thanks, David.
