### PR TITLE
readme: use https clone url in quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requirements: Vim 7.2.051 or above.
 
      ```
      $ mkdir -p ~/.vim/bundle
-     $ git clone git://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
+     $ git clone https://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
      ```
 
 2. Configure bundles:


### PR DESCRIPTION
The git:// transport does not use TLS and is therefore vulnerable to
man-in-the-middle attacks and DNS poisoning.  Recommend to use the
http:// clone URL instead.
