### PR TITLE
readme: add tip on handling make/gmake discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,18 @@ Requirements: Vim 7.2.051 or above.
 ## Docs
 
 see `:h neobundle`
+
+
+## Tips
+
+If you use a single .vimrc across systems where build programs are
+named differently (e.g. GNU Make is often `gmake` on non-GNU
+systems), the following pattern is useful:
+
+```vim
+let g:make = 'gmake'
+if system('uname -o') =~ '^GNU/'
+        let g:make = 'make'
+endif
+NeoBundle 'Shougo/vimproc.vim', {'build': {'unix': g:make}}
+```


### PR DESCRIPTION
Add a section to the README with a tip on handling make vs gmake on different systems, or
similar situations.
