### PR TITLE
Repository Name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Refer to `:help neobundle` for more examples and for a full list of commands.
      " My Bundles here:
      NeoBundle 'Shougo/neosnippet.vim'
      NeoBundle 'Shougo/neosnippet-snippets.vim'
-     NeoBundle 'tpope/vim-fugitive.vim'
+     NeoBundle 'tpope/vim-fugitive'
      NeoBundle 'kien/ctrlp.vim'
      NeoBundle 'flazz/vim-colorschemes'
 


### PR DESCRIPTION
The .vim is not apart of the repository name.
