### PR TITLE
Update path for neosnippet-snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Refer to `:help neobundle` for more examples and for a full list of commands.
 
      " My Bundles here:
      NeoBundle 'Shougo/neosnippet.vim'
-     NeoBundle 'Shougo/neosnippet-snippets.vim'
+     NeoBundle 'Shougo/neosnippet-snippets'
      NeoBundle 'tpope/vim-fugitive'
      NeoBundle 'kien/ctrlp.vim'
      NeoBundle 'flazz/vim-colorschemes'


### PR DESCRIPTION
This updates the example configuration file to give an error-free installation experience for the user. The previous path has been changed and gave the error:

```
neosnippet default snippets cannot be loaded.
You must install neosnippet-snippets or disable runtime snippets.
Press ENTER or type command to continue
```
