### PR TITLE
fix: /after directory had not added to 'runtimepath'

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -69,7 +69,7 @@ function! neobundle#config#final() "{{{
     let index += 1
 
     if isdirectory(rtp.'/after')
-      execute 'set rtp+='.fnameescape(rtp.'/after')
+      call add(rtps, fnameescape(rtp.'/after'))
     endif
   endfor
   let &runtimepath = neobundle#util#join_rtp(rtps, &runtimepath, '')


### PR DESCRIPTION
neobundle#begin() ~ neobundle#end() で管理すると、 after ディレクトリが追加されないみたいなので、修正してみました。
