### PR TITLE
Fix parser local by specifying packages in Windows

### DIFF
--- a/autoload/neobundle/parser.vim
+++ b/autoload/neobundle/parser.vim
@@ -172,8 +172,8 @@ function! neobundle#parser#local(localdir, options, names) "{{{
   let base = fnamemodify(neobundle#util#expand(a:localdir), ':p')
   for dir in filter(map(filter(split(glob(
         \ base . '*'), '\n'), "isdirectory(v:val)"),
-        \ "neobundle#util#substitute_path_separator(
-        \   substitute(fnamemodify(v:val, ':p'), '/$', '', ''))"),
+        \ "substitute(neobundle#util#substitute_path_separator(
+        \   fnamemodify(v:val, ':p')), '/$', '', '')"),
         \ "empty(a:names) || index(a:names, fnamemodify(v:val, ':t')) >= 0")
     let options = extend({ 'local' : 1, 'base' : base }, a:options)
     let name = fnamemodify(dir, ':t')


### PR DESCRIPTION
`neobundle#local({directory}, [{options}, [{names}]])` のnamesによるディレクトリ指定が
Windowsで正常に動作しない点を修正しました。

お手数をお掛けしますが、ご確認の上、マージして頂けますようお願いいたします。

確認環境: Windows8.1 64bit KaoriYa gVim 7.4.274
