### PR TITLE
Add `neobundle#has_fresh_cache`, which compares it to $MYVIMRC

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -220,7 +220,16 @@ function! neobundle#is_sourced(name)
 endfunction
 
 function! neobundle#has_cache()
-  return filereadable(neobundle#get_rtp_dir() . '/cache.vim')
+  return filereadable(neobundle#commands#get_cache_file())
+endfunction
+
+function! neobundle#has_fresh_cache()
+  " Check if the cache file is newer than the vimrc file (if it exists,
+  " which is not the case for `vim -u NONE`).
+  let cache = neobundle#commands#get_cache_file()
+  return filereadable(cache)
+        \ && ($MYVIMRC == ''
+        \    || getftime(cache) >= getftime($MYVIMRC))
 endfunction
 
 function! neobundle#get_not_installed_bundle_names()

--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -402,13 +402,17 @@ function! neobundle#commands#complete_deleted_bundles(arglead, cmdline, cursorpo
         \ 'stridx(v:val, a:arglead) == 0')
 endfunction"}}}
 
+function! neobundle#commands#get_cache_file() "{{{
+  return neobundle#get_rtp_dir() . '/cache.vim'
+endfunction"}}}
+
 function! neobundle#commands#save_cache() "{{{
   if !has('vim_starting')
     " Ignore if loaded
     return
   endif
 
-  let cache = neobundle#get_rtp_dir() . '/cache.vim'
+  let cache = neobundle#commands#get_cache_file()
   let bundles = deepcopy(neobundle#config#get_neobundles())
   " Clear hooks.  Because, VimL cannot save functions in JSON.
   for bundle in bundles
@@ -418,7 +422,7 @@ function! neobundle#commands#save_cache() "{{{
   call writefile([s:get_cache_version(), string(bundles)], cache)
 endfunction"}}}
 function! neobundle#commands#load_cache() "{{{
-  let cache = neobundle#get_rtp_dir() . '/cache.vim'
+  let cache = neobundle#commands#get_cache_file()
   if !filereadable(cache)
     return
   endif
@@ -441,7 +445,7 @@ function! neobundle#commands#load_cache() "{{{
   endtry
 endfunction"}}}
 function! neobundle#commands#clear_cache() "{{{
-  let cache = neobundle#get_rtp_dir() . '/cache.vim'
+  let cache = neobundle#commands#get_cache_file()
   if !filereadable(cache)
     return
   endif

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -284,10 +284,10 @@ neobundle#untap()				 *neobundle#untap()*
 
 neobundle#has_cache()			 *neobundle#has_cache()*
 		Checks if a cache file is generated.
-		You can optimize loading .vimrc time by it and
-		|:NeoBundleLoadCache|.
-		Note: You must clear cache by |:NeoBundleClearCache| if .vimrc
-		file is changed.
+		You can optimize the .vimrc loading time by using it
+		together with |:NeoBundleLoadCache|.
+		Note: You must clear the cache by using |:NeoBundleClearCache|
+		if the neobundle configuration is changed.
 >
 	if neobundle#has_cache()
 	  NeoBundleLoadCache
@@ -297,6 +297,11 @@ neobundle#has_cache()			 *neobundle#has_cache()*
 	  NeoBundleSaveCache
 	endif
 <
+neobundle#has_fresh_cache()		 *neobundle#has_fresh_cache()*
+		Similar to |neobundle#has_cache|, but compares the
+		modification time of the cache file to your configuration file
+		(|$MYVIMRC|).
+
 ------------------------------------------------------------------------------
 COMMANDS 					*neobundle-commands*
 
@@ -456,7 +461,8 @@ COMMANDS 					*neobundle-commands*
 
 						*:NeoBundleLoadCache*
 :NeoBundleLoadCache
-		Load plugin configuration from the cache file.
+		Load plugin configuration from the cache file,
+		which is located in `neobundle#get_rtp_dir() . '/cache.vim'`.
 
 						*:NeoBundleClearCache*
 :NeoBundleClearCache


### PR DESCRIPTION
This allows for easy cache busting, if you have edited your vimrc.

I have not changed the example code for `has_cache`, since you might often
change things not related to the cache, but it's useful to have it as a
helper method.
