### PR TITLE
Update the document to sync with the latest vimproc

### DIFF
--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -1510,22 +1510,15 @@ Q: I want to compile vimproc automatically.
 
 A:
 >
-	let vimproc_updcmd = has('win64') ?
-	  \ 'tools\\update-dll-mingw 64' : 'tools\\update-dll-mingw 32'
-	execute "NeoBundle 'Shougo/vimproc.vim'," . string({
+	NeoBundle 'Shougo/vimproc.vim', {
 		\ 'build' : {
-		\     'windows' : vimproc_updcmd,
+		\     'windows' : 'tools\\update-dll-mingw',
 		\     'cygwin' : 'make -f make_cygwin.mak',
 		\     'mac' : 'make -f make_mac.mak',
 		\     'unix' : 'make -f make_unix.mak',
 		\    },
-		\ })
+		\ }
 <
-Note that arguments of NeoBundle command are evaluated inside the NeoBundle
-command. Thus, local variables cannot be passed to NeoBundle command. If you
-want to use local variables as arguments of NeoBundle command, you have to
-expand them into a string and pass it to `:execute` command.
-
 
 Q: What's the "outdated" plugin?
 


### PR DESCRIPTION
vimprocのupdate-dll-mingw.batを使った際に、CPUのビット数を自動判別するようにしましたので、それに合わせたドキュメントの更新です。
