### PR TITLE
fix unite complete

### DIFF
--- a/autoload/unite/sources/neobundle_install.vim
+++ b/autoload/unite/sources/neobundle_install.vim
@@ -120,7 +120,7 @@ endfunction"}}}
 
 function! s:source_install.complete(args, context, arglead, cmdline, cursorpos) "{{{
   return ['!'] +
-        \ neobundle#complete_bundles(a:arglead, a:cmdline, a:cursorpos)
+        \ neobundle#commands#complete_bundles(a:arglead, a:cmdline, a:cursorpos)
 endfunction"}}}
 
 let s:source_update = deepcopy(s:source_install)


### PR DESCRIPTION
:Unite neobundle/install:<<タブキー>>
とした際にエラーが出ていました。
neobundle#complete_bundles ではなく neobundle#commands#complete_bundles とするのが正しいと思うのですが、いかがでしょうか。
