### PR TITLE
Add {vimrc} argument to neobundle#has_fresh_cache()

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -223,13 +223,13 @@ function! neobundle#has_cache()
   return filereadable(neobundle#commands#get_cache_file())
 endfunction
 
-function! neobundle#has_fresh_cache()
-  " Check if the cache file is newer than the vimrc file (if it exists,
-  " which is not the case for `vim -u NONE`).
+function! neobundle#has_fresh_cache(...)
+  " Check if the cache file is newer than the vimrc file.
+  let vimrc = get(a:000, 0, $MYVIMRC)
   let cache = neobundle#commands#get_cache_file()
   return filereadable(cache)
-        \ && ($MYVIMRC == ''
-        \    || getftime(cache) >= getftime($MYVIMRC))
+        \ && (!filereadable(vimrc)
+        \    || getftime(cache) >= getftime(vimrc))
 endfunction
 
 function! neobundle#get_not_installed_bundle_names()

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -298,10 +298,10 @@ neobundle#has_cache()			 *neobundle#has_cache()*
 	  NeoBundleSaveCache
 	endif
 <
-neobundle#has_fresh_cache()		 *neobundle#has_fresh_cache()*
+neobundle#has_fresh_cache([{vimrc}])	 *neobundle#has_fresh_cache()*
 		Similar to |neobundle#has_cache|, but compares the
 		modification time of the cache file to your configuration file
-		(|$MYVIMRC|).
+		({vimrc} or |$MYVIMRC|).
 
 ------------------------------------------------------------------------------
 COMMANDS 					*neobundle-commands*


### PR DESCRIPTION
`neobundle#has_fresh_cache()` に `{vimrc}` 引数追加してみました。
私は neobundle の設定は別ファイルに分けてそいつを vimrc から `:source` しているので、そういう場合に以下の様な感じで使います。

``` vim
call neobundle#begin()

if neobundle#has_fresh_cache(expand('<sfile>'))
  NeoBundleLoadCache
  call neobundle#end()
  filetype plugin indent on
  finish
endif

" 通常の設定…
```
