### PR TITLE
Use `--ff --ff-only` instead of `--rebase` with `git pull`

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -39,6 +39,8 @@ call neobundle#util#set_default(
 call neobundle#util#set_default(
       \ 'g:neobundle#types#git#clone_depth', 0,
       \ 'g:neobundle_git_clone_depth')
+call neobundle#util#set_default(
+      \ 'g:neobundle#types#git#pull_command', 'pull --ff --ff-only')
 "}}}
 
 function! neobundle#types#git#define() "{{{
@@ -116,7 +118,7 @@ function! s:type.get_sync_command(bundle) "{{{
 
     let cmd .= printf(' %s "%s"', a:bundle.uri, a:bundle.path)
   else
-    let cmd = 'pull --ff --ff-only'
+    let cmd = g:neobundle#types#git#pull_command
     if g:neobundle#types#git#enable_submodule
       let shell = fnamemodify(split(&shell)[0], ':t')
       let and = (!neobundle#util#has_vimproc() && shell ==# 'fish') ?

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -587,6 +587,13 @@ g:neobundle#types#git#clone_depth
 
 		Defaults to 0.
 
+				*g:neobundle#types#git#pull_command*
+g:neobundle#types#git#pull_command
+		The git command used to pull updates.
+		The previous default has been "pull --rebase".
+
+		Defaults to "pull --ff --ff-only".
+
 				*g:neobundle#types#hg#command_path*
 g:neobundle#types#hg#command_path
 		The "hg" command path used for hg type.


### PR DESCRIPTION
Given a dirty worktree (with changed files), `git pull --ff --ff-only`
behaves better that `git pull --rebase` when updating plugins.

Fixes: https://github.com/Shougo/neobundle.vim/issues/305
