### PR TITLE
Detect git better

### DIFF
--- a/autoload/neobundle/util.vim
+++ b/autoload/neobundle/util.vim
@@ -44,6 +44,32 @@ function! neobundle#util#expand(path) "{{{
   return (s:is_windows && path =~ '\\') ?
         \ neobundle#util#substitute_path_separator(path) : path
 endfunction"}}}
+function! neobundle#util#join_paths(path1, path2) "{{{
+  " Joins two paths together, handling the case where the second path
+  " is an absolute path.
+  if s:is_absolute(a:path2)
+    return a:path2
+  endif
+  if a:path1 =~ (s:is_windows ? '[\\/]$' : '/$') ||
+        \ a:path2 =~ (s:is_windows ? '^[\\/]' : '^/')
+    " the appropriate separator already exists
+    return a:path1 . a:path2
+  else
+    " note: I'm assuming here that '/' is always valid as a directory
+    " separator on Windows. I know Windows has paths that start with \\?\ that
+    " diasble behavior like that, but I don't know how Vim deals with that.
+    return a:path1 . '/' . a:path2
+  endif
+endfunction "}}}
+if s:is_windows
+  function! s:is_absolute(path) "{{{
+    return a:path =~ '^[\\/]\|^\a:'
+  endfunction "}}}
+else
+  function! s:is_absolute(path) "{{{
+    return a:path =~ "^/"
+  endfunction "}}}
+endif
 
 function! neobundle#util#is_windows() "{{{
   return s:is_windows


### PR DESCRIPTION
.git can be a file with a special format, not just a directory. This is
commonly used for submodules.

Also verify that the layout of the .git dir includes the 3 required
children that git itself uses to decide if the directory is a valid git
directory.

Note: I wrote the path functions such that they should work on Windows, but I have no way to actually test Windows support.
