### PR TITLE
E121: Undefined variable: name

### DIFF
--- a/autoload/neobundle/types/git.vim
+++ b/autoload/neobundle/types/git.vim
@@ -214,6 +214,7 @@ function! s:parse_other_pattern(protocol, path, opts) "{{{
   let uri = ''
 
   if a:path =~# '\<gist:\S\+\|://gist.github.com/'
+    let name = split(a:path, ':')[-1]
     let uri =  (a:protocol ==# 'ssh') ?
           \ 'git@gist.github.com:' . split(name, '/')[-1] :
           \ a:protocol . '://gist.github.com/'. split(name, '/')[-1]


### PR DESCRIPTION
bug fix

```
E121: Undefined variable: name
E116: Invalid arguments for function split(name, '/')[-1]
E15: Invalid expression: (a:protocol ==# 'ssh') ? 'git@gist.github.com:' . split(name, '/')[-1] : a:protocol . '://gist.github.com/'. split(name, '/')[-1]
Failed parse name "git://gist.github.com/9133200.git" and args {'recipe': '', 'default': '_', 'script_type': 'plugin'}
```
