### PR TITLE
Updating install.sh to change the repo used for ctrlp

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -50,7 +50,7 @@ echo "Please add the following settings for NeoBundle to the top of your .vimrc 
     echo "NeoBundle 'Shougo/neosnippet.vim'"
     echo "NeoBundle 'Shougo/neosnippet-snippets'"
     echo "NeoBundle 'tpope/vim-fugitive'"
-    echo "NeoBundle 'kien/ctrlp.vim'"
+    echo "NeoBundle 'ctrlpvim/ctrlp.vim'"
     echo "NeoBundle 'flazz/vim-colorschemes'"
     echo ""
     echo "\" You can specify revision/branch/tag."


### PR DESCRIPTION
Kein seems to have disappeared and the ctrlp.vim project from him has stagnated. There is an active fork under  https://github.com/ctrlpvim/ctrlp.vim  as a result of issue 591 ( https://github.com/kien/ctrlp.vim/issues/591 ). I propose switching to that instead.
