### PR TITLE
NeoBundleCheck: defer call always

### DIFF
--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -137,8 +137,9 @@ function! neobundle#commands#check() "{{{
     return
   endif
 
-  if has('gui_running') && has('vim_starting')
-    " Note: :NeoBundleCheck cannot work in GUI startup.
+  " Defer call during Vim startup.
+  " This is required for 'gui_running' and fixes issues otherwise.
+  if has('vim_starting')
     autocmd neobundle VimEnter * NeoBundleCheck
   else
     echomsg 'Not installed bundles: '


### PR DESCRIPTION
While it basically works for `!has('gui_running')`, it causes problems:
 - localvimrc does not use the `g:localvimrc_persistent` setting
 - ryanoasis/vim-webdevicons gets loaded twice for airline
 - mappings for vim-tmux-navigator are not being setup

Instead of debugging this, it seems to be more consistent to just use
the same mechanism for GUI and non-GUI.