### PR TITLE
fix lazy autoload existing special char in mappings.

### DIFF
--- a/autoload/neobundle/autoload.vim
+++ b/autoload/neobundle/autoload.vim
@@ -253,8 +253,10 @@ function! s:get_input()
 
   call feedkeys(termstr, 'n')
 
+  let type_num = type(0)
   while 1
-    let input .= nr2char(getchar())
+    let char = getchar()
+    let input .= type(char) == type_num ? nr2char(char) : char
 
     let idx = stridx(input, termstr)
     if idx >= 1


### PR DESCRIPTION
NeoBundleLazy の `autoload` に `mappings`を指定しているとき、
そのトリガーとなる入力に特殊な文字 `<Plug>` や `<F5>` などを含んでいると
ヤバいことになる問題を解決します。

直近の問題では vim-submode の呼び出しがありました。
http://lingr.com/room/vim/archives/2015/01/29#message-21160180

この問題は過去にも何らかの形で言及されていたのですが、ソースが見つけられませんでした。

原因は nr2char(getchar()) の部分で、getchar() が数字として取得しないVim の特殊な入力
`<Plug>` や `<F4>` などをnr2char() に渡しているためにその入力の情報が失われてしまうことでした。

#170 の問題の解決でした。