### PR TITLE
Fix neobundle#autoload#command behavior called with range option

### DIFF
--- a/autoload/neobundle/autoload.vim
+++ b/autoload/neobundle/autoload.vim
@@ -110,7 +110,9 @@ function! neobundle#autoload#command(command, name, args, bang, line1, line2)
 
   call neobundle#config#source(a:name)
 
-  let range = (a:line1 != a:line2) ? "'<,'>" : ''
+  let range = (a:line1 == a:line2) ? '' :
+        \ (a:line1==line("'<") && a:line2==line("'>")) ?
+        \ "'<,'>" : a:line1.",".a:line2
 
   try
     execute range.a:command.a:bang a:args


### PR DESCRIPTION
issue #190 の解決のために，範囲が渡された場合は"'<,'>"を付加するようになっているようですが，
これだと%や行番号を渡した場合に上手く動きませんでした．
両方を踏まえて，始点終点が一致した場合は"'<,'>"を，そうでない場合は行番号を付加するようにしました．
確認のほどお願いします．