### PR TITLE
Trim off a -vim suffix when generating the default function prefix

### DIFF
--- a/autoload/neobundle/parser.vim
+++ b/autoload/neobundle/parser.vim
@@ -269,7 +269,7 @@ endfunction"}}}
 function! neobundle#parser#_function_prefix(name) "{{{
   let function_prefix = tolower(fnamemodify(a:name, ':r'))
   let function_prefix = substitute(function_prefix,
-        \'^vim-', '','')
+        \'^vim-\|-vim$', '','')
   let function_prefix = substitute(function_prefix,
         \'^unite-', 'unite#sources#','')
   let function_prefix = tr(function_prefix, '-', '_')

--- a/test/parse.vim
+++ b/test/parse.vim
@@ -211,6 +211,9 @@ function! s:suite.parse_function_prefix()
 
   call s:assert.equals(neobundle#parser#_function_prefix(
         \ 'vim-vcs'), 'vcs')
+
+  call s:assert.equals(neobundle#parser#_function_prefix(
+        \ 'gist-vim'), 'gist')
 endfunction
 
 function! s:suite.name_conversion()


### PR DESCRIPTION
This handles repositories like `mattn/webapi-vim`.