### PR TITLE
Use clipboard register when to yank

### DIFF
--- a/autoload/unite/sources/neobundle_search.vim
+++ b/autoload/unite/sources/neobundle_search.vim
@@ -149,7 +149,7 @@ function! s:source.action_table.yank.func(candidates) "{{{
   let @" = join(map(a:candidates,
         \ "'NeoBundle ' . s:get_neobundle_args(v:val)"), "\n")
   if has('clipboard')
-    call setreg(v:register, text)
+    call setreg(v:register, @")
   endif
 
   echo 'Yanked plugin settings!'

--- a/autoload/unite/sources/neobundle_search.vim
+++ b/autoload/unite/sources/neobundle_search.vim
@@ -149,7 +149,7 @@ function! s:source.action_table.yank.func(candidates) "{{{
   let @" = join(map(a:candidates,
         \ "'NeoBundle ' . s:get_neobundle_args(v:val)"), "\n")
   if has('clipboard')
-    let @* = @"
+    call setreg(v:register, text)
   endif
 
   echo 'Yanked plugin settings!'


### PR DESCRIPTION
Enable yank action correctly to use correct clipboard register.
It's same way of yanking in unite.vim 