### PR TITLE
Update Github Web API version of unite source 'neobundle/search' 

### DIFF
--- a/autoload/neobundle/sources/github.vim
+++ b/autoload/neobundle/sources/github.vim
@@ -45,15 +45,15 @@ function! s:source.gather_candidates(args, context) "{{{
 
   let plugins = s:get_github_searches(a:context.source__input)
 
+
   return map(copy(plugins), "{
-        \ 'word' : v:val.username.'/'.v:val.name . ' ' . v:val.description,
+        \ 'word' : v:val.full_name. ' ' . v:val.description,
         \ 'source__name' : (v:val.fork ? '| ' : '') .
-        \          v:val.username.'/'.v:val.name,
-        \ 'source__path' : v:val.username.'/'.v:val.name,
+        \          v:val.full_name,
+        \ 'source__path' : v:val.full_name,
         \ 'source__description' : v:val.description,
         \ 'source__options' : [],
-        \ 'action__uri' : 'https://github.com/' .
-        \        v:val.username.'/'.v:val.name,
+        \ 'action__uri' : v:val.html_url,
         \ }")
 endfunction"}}}
 
@@ -62,8 +62,8 @@ endfunction"}}}
 " @vimlint(EVL102, 1, l:false)
 " @vimlint(EVL102, 1, l:null)
 function! s:get_github_searches(string) "{{{
-  let path = 'https://api.github.com/legacy/repos/search/'
-        \ . a:string . '*?language=VimL'
+  let path = 'https://api.github.com/search/repositories?q='
+        \ . a:string . '+language:VimL'.'\&sort=stars'.'\&order=desc'
   let temp = neobundle#util#substitute_path_separator(tempname())
 
   let cmd = printf('%s "%s" "%s"', 'wget -q -O ', temp, path)
@@ -89,12 +89,12 @@ function! s:get_github_searches(string) "{{{
 
   let [true, false, null] = [1,0,"''"]
   sandbox let data = eval(join(readfile(temp)))
-  call filter(data.repositories,
-        \ "stridx(v:val.username.'/'.v:val.name, a:string) >= 0")
+  call filter(data.items,
+        \ "stridx(v:val.full_name, a:string) >= 0")
 
   call delete(temp)
 
-  return data.repositories
+  return data.items
 endfunction"}}}
 " @vimlint(EVL102, 0, l:true)
 " @vimlint(EVL102, 0, l:false)

--- a/autoload/neobundle/sources/github.vim
+++ b/autoload/neobundle/sources/github.vim
@@ -35,6 +35,19 @@ let s:source = {
       \ 'short_name' : 'github',
       \ }
 
+" sorter 
+let s:filter = {
+\   "name" : "sorter_stars",
+\}
+
+function! s:filter.filter(candidates, context)
+    " v:val.source__track.artist で sort
+    return unite#util#sort_by(a:candidates, 'v:val.source__stars')
+endfunction
+
+call unite#define_filter(s:filter)
+unlet s:filter
+
 function! s:source.gather_candidates(args, context) "{{{
   if !executable('wget')
     call unite#print_error(
@@ -52,6 +65,7 @@ function! s:source.gather_candidates(args, context) "{{{
         \          v:val.full_name,
         \ 'source__path' : v:val.full_name,
         \ 'source__description' : v:val.description,
+        \ 'source__stars' : v:val.stargazers_count,
         \ 'source__options' : [],
         \ 'action__uri' : v:val.html_url,
         \ }")
@@ -99,6 +113,8 @@ endfunction"}}}
 " @vimlint(EVL102, 0, l:true)
 " @vimlint(EVL102, 0, l:false)
 " @vimlint(EVL102, 0, l:null)
+
+call unite#custom_source('neobundle/search', 'sorters', 'sorters_stars')
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/unite/sources/neobundle_search.vim
+++ b/autoload/unite/sources/neobundle_search.vim
@@ -149,7 +149,7 @@ function! s:source.action_table.yank.func(candidates) "{{{
   let @" = join(map(a:candidates,
         \ "'NeoBundle ' . s:get_neobundle_args(v:val)"), "\n")
   if has('clipboard')
-    let @* = @"
+    call setreg(v:register, @")
   endif
 
   echo 'Yanked plugin settings!'


### PR DESCRIPTION
Make it use github v3.0 Web API.

Conventional API has already been old and there are some problems for search.
Retrieval omission caused in githubv2.0(i.e. query 'watchdogs'  can't hit 'osyo-manga/vim-watchdogs')

Besides this updates, I define new sorters which put repositories in order by its stargazers_count for user-friendly selection.