### PR TITLE
depends option with arguments in TOML

### DIFF
--- a/autoload/neobundle/parser.vim
+++ b/autoload/neobundle/parser.vim
@@ -227,6 +227,27 @@ function! neobundle#parser#load_toml(filename, default) "{{{
       return 1
     endif
 
+    if has_key(plugin, 'depends')
+      let _ = []
+      for depend in neobundle#util#convert2list(plugin.depends)
+        if type(depend) == type('') || type(depend) == type([])
+          call add(_, depend)
+        elseif type(depend) == type({})
+          if !has_key(depend, 'repository')
+            call neobundle#util#print_error(
+                  \ '[neobundle] No repository plugin data: ' . a:filename)
+            return 1
+          endif
+
+          call add(_, [depend.repository, depend])
+        endif
+
+        unlet depend
+      endfor
+
+      let plugin.depends = _
+    endif
+
     let options = extend(plugin, a:default, 'keep')
     " echomsg plugin.repository
     " echomsg string(options)

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -252,6 +252,10 @@ neobundle#load_toml({filename}, [{options}])
 		unite_sources = [ 'neosnippet',
 		  'neosnippet/user', 'neosnippet/runtime']
 
+		  [[plugins.depends]]
+		  repository = 'honza/vim-snippet'
+		  name = 'honza-snippet'
+
 		[[plugins]]
 		repository = 'Shougo/neobundle.vim'
 		fetch = 1


### PR DESCRIPTION
```vim
" doc/neobundle.txt から抜粋
NeoBundle 'Shougo/neocomplcache', {'depends' :
    \ [ 'Shougo/neosnippet.git',
    \   ['rstacruz/sparkup', {'rtp': 'vim'}],
    \ ]}
```
上記に相当する記述(`['{plugin-name}', {args}]`)が
TOMLで記述出来なそうなので作成
```toml
[[plugins]]
repository = 'Shougo/neocomplcache'
depends = ['Shougo/neosnippet.git']

  [[plugin.depends]]
  repository = 'rstacruz/sparkup'
  rtp = 'vim'
```
しかし`depends`をパースし直す関係上`load_toml()`の処理時間は増えてしまう