### PR TITLE
Add neobundle#util#redir and make use of it

### DIFF
--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -476,9 +476,7 @@ function! neobundle#commands#save_cache() "{{{
     let bundle.hooks = {}
   endfor
 
-  redir => current_vim
-  silent! version
-  redir END
+  let current_vim = neobundle#util#redir('version')
 
   call writefile( [s:get_cache_version(),
         \ v:progname, current_vim, string(bundles)], cache)
@@ -490,9 +488,7 @@ function! neobundle#commands#load_cache(...) "{{{
     return 1
   endif
 
-  redir => current_vim
-  silent! version
-  redir END
+  let current_vim = neobundle#util#redir('version')
 
   try
     let list = readfile(cache)

--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -179,9 +179,7 @@ function! neobundle#config#source(names, ...) "{{{
     return
   endif
 
-  redir => filetype_before
-  silent autocmd FileType
-  redir END
+  let filetype_before = neobundle#util#redir("autocmd FileType")
 
   let reset_ftplugin = 0
   for bundle in bundles
@@ -216,9 +214,7 @@ function! neobundle#config#source(names, ...) "{{{
     endif
   endfor
 
-  redir => filetype_after
-  silent autocmd FileType
-  redir END
+  let filetype_after = neobundle#util#redir('autocmd FileType')
 
   if reset_ftplugin
     call s:reset_ftplugin()
@@ -744,9 +740,7 @@ function! s:reset_ftplugin() "{{{
 endfunction"}}}
 
 function! s:filetype_off() "{{{
-  redir => filetype_out
-  silent filetype
-  redir END
+  let filetype_out = neobundle#util#redir('filetype')
 
   if filetype_out =~# 'plugin:ON'
         \ || filetype_out =~# 'indent:ON'

--- a/autoload/neobundle/installer.vim
+++ b/autoload/neobundle/installer.vim
@@ -726,12 +726,5 @@ function! s:reload(bundles) "{{{
   call neobundle#call_hook('on_post_source', a:bundles)
 endfunction"}}}
 
-function! s:redir(cmd) "{{{
-  redir => res
-  silent! execute a:cmd
-  redir END
-  return res
-endfunction"}}}
-
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/neobundle/util.vim
+++ b/autoload/neobundle/util.vim
@@ -328,6 +328,19 @@ function! neobundle#util#sort_by(list, expr) "{{{
   \      'a:a[1] ==# a:b[1] ? 0 : a:a[1] ># a:b[1] ? 1 : -1'), 'v:val[0]')
 endfunction"}}}
 
+" Executes a command and returns its output.
+" This wraps Vim's `:redir`, and makes sure that the `verbose` settings have
+" no influence.
+function! neobundle#util#redir(cmd) abort "{{{
+  let [save_verbose, save_verbosefile] = [&verbose, &verbosefile]
+  set verbose=0 verbosefile=
+  redir => res
+    silent! execute a:cmd
+  redir END
+  let [&verbose, &verbosefile] = [save_verbose, save_verbosefile]
+  return res
+endfunction"}}}
+
 " Sorts a list with expression to compare each two values.
 " a:a and a:b can be used in {expr}.
 function! s:sort(list, expr) "{{{


### PR DESCRIPTION
This fixes Neobundle behaving different with regard to filetype
autoloading with `-V14` vs. `-V15`, where the output from `autocmd
Filetype` differs because of the more verbose output:

    ^@line 15:   silent autocmd FileType^@--- Auto-Commands ---^@neobundle  FileType^@    *         call neobundle#autoload#filetype()^@line 16:   redir END
    =>
    ^@line 53:   silent autocmd FileType^@--- Auto-Commands ---^@neobundle  FileType^@    *         call neobundle#autoload#filetype()^@line 54:   redir END

This is taken from [themis](https://github.com/thinca/vim-themis/blob/2568862b7298b0665693eff99af69fe18f210f84/autoload/themis/helper/assert.vim#L388-396).