### PR TITLE
Add verbose message for FileType handling

### DIFF
--- a/autoload/neobundle/config.vim
+++ b/autoload/neobundle/config.vim
@@ -217,8 +217,16 @@ function! neobundle#config#source(names, ...) "{{{
   let filetype_after = neobundle#util#redir('autocmd FileType')
 
   if reset_ftplugin
+    if &verbose
+      echom "Neobundle: resetting ftplugin, after loading bundles:"
+            \ join(map(copy(bundles), 'v:val.name'), ", ")
+    endif
     call s:reset_ftplugin()
   elseif filetype_before !=# filetype_after
+    if &verbose
+      echom "Neobundle: FileType autocommand triggered by:"
+            \ join(map(copy(bundles), 'v:val.name'), ", ")
+    endif
     execute 'doautocmd FileType' &filetype
   endif
 

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -1063,6 +1063,13 @@ OPTIONS 					*neobundle-options*
 			filetypes	(List) or (String)
 			Filetype list.  If the filetype is "all", it means all
 			filetypes.
+			NOTE: Using this will usually cause Neobundle to
+			either reset the ftplugin state, or explicitly call
+			the FileType autocommand another time (after adding
+			the lazy-loaded bundle), which results in the
+			autocommand to be processed twice for all other
+			plugins.  Therefore, using "all" does not make sense
+			usually.
 
 			filename_patterns	(List) or (String)
 			Filename regex pattern list.


### PR DESCRIPTION
It is useful to know that Neobundle resets and/or triggers the FileType
autocommand.  This patch adds a message in case &verbose is set, and
displays the bundles in the context.

It could be improved to only display the bundle(s) that triggered the
resetting, but it's probably not worth it and not so easy for when
"only" the `FileType` autocommand is triggered.  In that case a diff of
the output from `autocmd FileType` might be useful.