### PR TITLE
Fix focus autoload

### DIFF
--- a/autoload/neobundle/autoload.vim
+++ b/autoload/neobundle/autoload.vim
@@ -62,7 +62,7 @@ function! neobundle#autoload#init()
     autocmd CursorHold * if s:active_auto_source
           \ | call s:source_focus()
           \ | endif
-    autocmd FocusLost * let s:active_auto_source = 1
+    autocmd FocusLost * let s:active_auto_source = 1 | call feedkeys("g\<ESC>", 'n')
     autocmd FocusGained * let s:active_auto_source = 0
   augroup END
 

--- a/autoload/neobundle/autoload.vim
+++ b/autoload/neobundle/autoload.vim
@@ -62,7 +62,7 @@ function! neobundle#autoload#init()
     autocmd CursorHold * if s:active_auto_source
           \ | call s:source_focus()
           \ | endif
-    autocmd FocusLost * let s:active_auto_source = 1 | call feedkeys("g\<ESC>", 'n')
+    autocmd FocusLost * let s:active_auto_source = 1 | call s:source_focus()
     autocmd FocusGained * let s:active_auto_source = 0
   augroup END
 


### PR DESCRIPTION
Using focus = 1 for autoload is currently broken, at least on MacVim.

This one-line change fixes it. The problem was that CursorHold was never triggered after FocusLost. Calling feedkeys() on FocusLost forces CursorHold to trigger in the background.