### PR TITLE
enable neobundle#load_cache() to handle multiple configuration file

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -152,7 +152,7 @@ command! -bar NeoBundleLoadCache
       \ 'It will be removed in the next version.') |
       \ call neobundle#util#print_error(
       \ 'Please use neobundle#load_cache() instead.') |
-      \ call neobundle#commands#load_cache()
+      \ call neobundle#commands#load_cache([$MYVIMRC])
 command! -bar NeoBundleClearCache
       \ call neobundle#commands#clear_cache()
 
@@ -285,8 +285,8 @@ function! neobundle#has_cache() "{{{
 endfunction"}}}
 
 function! neobundle#load_cache(...) "{{{
-  let vimrc = get(a:000, 0, $MYVIMRC)
-  return neobundle#commands#load_cache(vimrc)
+  let vimrcs = len(a:000) == 0 ? [$MYVIMRC] : a:000
+  return neobundle#commands#load_cache(vimrcs)
 endfunction"}}}
 
 function! neobundle#has_fresh_cache(...) "{{{

--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -485,10 +485,16 @@ function! neobundle#commands#save_cache() "{{{
         \ v:progname, current_vim, string(bundles)], cache)
 endfunction"}}}
 function! neobundle#commands#load_cache(...) "{{{
-  let vimrc = get(a:000, 0, $MYVIMRC)
   let cache = neobundle#commands#get_cache_file()
-  if !filereadable(cache) || getftime(cache) < getftime(vimrc)
-    return 1
+  if !filereadable(cache) | return 1 | endif
+
+  let vimrc = get(a:000, 0, $MYVIMRC)
+  if type(vimrc) == 1
+    if getftime(cache) < getftime(vimrc) | return 1 | endif
+  else
+    for elem in vimrc
+      if getftime(cache) < getftime(elem) | return 1 | endif
+    endfor
   endif
 
   let current_vim = neobundle#util#redir('version')

--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -484,18 +484,13 @@ function! neobundle#commands#save_cache() "{{{
   call writefile( [neobundle#get_cache_version(),
         \ v:progname, current_vim, string(bundles)], cache)
 endfunction"}}}
-function! neobundle#commands#load_cache(...) "{{{
+function! neobundle#commands#load_cache(vimrcs) "{{{
   let cache = neobundle#commands#get_cache_file()
   if !filereadable(cache) | return 1 | endif
 
-  let vimrc = get(a:000, 0, $MYVIMRC)
-  if type(vimrc) == 1
+  for vimrc in a:vimrcs
     if getftime(cache) < getftime(vimrc) | return 1 | endif
-  else
-    for elem in vimrc
-      if getftime(cache) < getftime(elem) | return 1 | endif
-    endfor
-  endif
+  endfor
 
   let current_vim = neobundle#util#redir('version')
 

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -364,7 +364,7 @@ neobundle#tap({bundle-name})			 *neobundle#tap()*
 		  " Define plugin mappings, commands, ...
 		  map f <Plug>(foo)
 		  command! FOO call foo#foo()
-		
+
 		  call neobundle#untap()
 		endif
 <
@@ -383,10 +383,11 @@ neobundle#has_fresh_cache()	 *neobundle#has_fresh_cache()*
 		Note: It is deprecated.  You should use
 		|neobundle#load_cache()| instead of it.
 
-neobundle#load_cache([{vimrc}])			 *neobundle#load_cache()*
+neobundle#load_cache([{vimrcs}])		 *neobundle#load_cache()*
 		Load plugin configuration from the cache file,
 		which is located in `neobundle#get_rtp_dir() . '/cache'`.
-		{vimrc} is compared .vimrc file.  The default is |$MYVIMRC|.
+		{vimrcs} is a list of compared .vimrc and/or other configuration
+		files. The default is |$MYVIMRC|.
 
 		It returns 1, if the cache file is old or invalid or not
 		found.
@@ -396,6 +397,14 @@ neobundle#load_cache([{vimrc}])			 *neobundle#load_cache()*
 >
 	if neobundle#load_cache()
 	  " My Bundles here:
+	  " ...
+	  NeoBundleSaveCache
+	endif
+<
+		If you use multiple configuration files,
+>
+	if neobundle#load_cache($MYVIMRC, 'plugin.vim', 'plugin.toml')
+	  " My Bundles here or other files spcified as arguments
 	  " ...
 	  NeoBundleSaveCache
 	endif


### PR DESCRIPTION
solves #469 .
`neobundle#commands#load_cache()` checks ftime of all the files passed to `neobundle#load_cache()`.