### PR TITLE
neobundle#commands#save_cache: sort by depends

### DIFF
--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -480,6 +480,8 @@ function! neobundle#commands#save_cache() "{{{
     let bundle.sourced = 0
   endfor
 
+  let bundles = sort(map(bundles, 'len(v:val.depends)'))
+
   let current_vim = neobundle#util#redir('version')
 
   call writefile( [neobundle#get_cache_version(),


### PR DESCRIPTION
Fixes https://github.com/Shougo/neobundle.vim/issues/474.

This is a very basic approach, but fixes the common case where the dependent bundles (which don't have `depends`) will come before the ones depending on them.