### PR TITLE
TBD: Skip cache without vimrc

### DIFF
--- a/autoload/neobundle.vim
+++ b/autoload/neobundle.vim
@@ -310,22 +310,6 @@ function! neobundle#load_cache(...) "{{{
   return neobundle#commands#load_cache(vimrcs)
 endfunction"}}}
 
-function! neobundle#has_fresh_cache(...) "{{{
-  call neobundle#util#print_error(
-        \ 'neobundle#has_fresh_cache() is deprecated function.')
-  call neobundle#util#print_error(
-        \ 'It will be removed in the next version.')
-  call neobundle#util#print_error(
-        \ 'Please use neobundle#load_cache() instead.')
-
-  " Check if the cache file is newer than the vimrc file.
-  let vimrc = get(a:000, 0, $MYVIMRC)
-  let cache = neobundle#commands#get_cache_file()
-  return filereadable(cache)
-        \ && (!filereadable(vimrc)
-        \    || getftime(cache) >= getftime(vimrc))
-endfunction"}}}
-
 function! neobundle#get_not_installed_bundle_names() "{{{
   return map(neobundle#get_not_installed_bundles([]), 'v:val.name')
 endfunction"}}}

--- a/autoload/neobundle/commands.vim
+++ b/autoload/neobundle/commands.vim
@@ -490,7 +490,8 @@ function! neobundle#commands#load_cache(vimrcs) "{{{
   if !filereadable(cache) | return 1 | endif
 
   for vimrc in a:vimrcs
-    if getftime(cache) < getftime(vimrc) | return 1 | endif
+    let vimrc_ftime = getftime(vimrc)
+    if vimrc_ftime != -1 && getftime(cache) < vimrc_ftime | return 1 | endif
   endfor
 
   let current_vim = neobundle#util#redir('version')

--- a/doc/neobundle.txt
+++ b/doc/neobundle.txt
@@ -376,13 +376,6 @@ neobundle#has_cache()			 *neobundle#has_cache()*
 		Note: It is deprecated.  You should use
 		|neobundle#load_cache()| instead of it.
 
-neobundle#has_fresh_cache()	 *neobundle#has_fresh_cache()*
-		Similar to |neobundle#has_cache|, but compares the
-		modification time of the cache file to your configuration file
-		({vimrc} or |$MYVIMRC|).
-		Note: It is deprecated.  You should use
-		|neobundle#load_cache()| instead of it.
-
 neobundle#load_cache([{vimrcs}])		 *neobundle#load_cache()*
 		Load plugin configuration from the cache file,
 		which is located in `neobundle#get_rtp_dir() . '/cache'`.


### PR DESCRIPTION
With `vim -u foo.vim`, `$MYVIMRC` (the default for `a:vimrcs`) is not
set/empty and cannot be used to check the cache's freshness: the cache
will be considered to be fresh always currently.

TODO: But overwriting an existing cache should also be prevented in this case!
Otherwise you will create a new cache file (from some custom vimrc),
which is then possibly newer than your vimrc.