### PR TITLE
Clarified statement development stopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Stories in Ready](https://badge.waffle.io/Shougo/neobundle.vim.png)](https://waffle.io/Shougo/neobundle.vim)
 
-Note: Current neobundle development status is just bug fix only.
+**Note**: Active developement on NeoBundle has stopped. The only future changes will be bug fixes.
+
+Please see [Dein.vim](https://github.com/Shougo/dein.vim) -- A faster, well-tested plugin manager for Vim and Neovim. It can do everything NeoBundle does, including asynchronous installs.
 
 ## About
 


### PR DESCRIPTION
This comment is based on [Shougo's comment on reddit](https://www.reddit.com/r/vim/comments/47qbv9/neobundle_on_hiatus_or_done/d0fcdel):

> NeoBundle development is done. I have replaced to dein.vim. Dein.vim is faster and well tested. And it implements neovim asynchronous installer.