### PR TITLE
Fix `unknown function: js_encode`

### DIFF
--- a/autoload/neobundle/util.vim
+++ b/autoload/neobundle/util.vim
@@ -285,7 +285,7 @@ function! neobundle#util#vim2json(expr) abort "{{{
   return has('patch-7.4.1498') ? json_encode(a:expr) : string(a:expr)
 endfunction "}}}
 function! neobundle#util#json2vim(expr) abort "{{{
-  sandbox return has('patch-7.4.1498') ? json_encode(a:expr) : eval(a:expr)
+  sandbox return has('patch-7.4.1498') ? json_decode(a:expr) : eval(a:expr)
 endfunction "}}}
 
 " Escape a path for runtimepath.

--- a/autoload/neobundle/util.vim
+++ b/autoload/neobundle/util.vim
@@ -282,10 +282,10 @@ function! neobundle#util#name_conversion(path) abort "{{{
 endfunction"}}}
 
 function! neobundle#util#vim2json(expr) abort "{{{
-  return has('patch-7.4.1498') ? js_encode(a:expr) : string(a:expr)
+  return has('patch-7.4.1498') ? json_encode(a:expr) : string(a:expr)
 endfunction "}}}
 function! neobundle#util#json2vim(expr) abort "{{{
-  sandbox return has('patch-7.4.1498') ? js_decode(a:expr) : eval(a:expr)
+  sandbox return has('patch-7.4.1498') ? json_encode(a:expr) : eval(a:expr)
 endfunction "}}}
 
 " Escape a path for runtimepath.


### PR DESCRIPTION
Fix error `Unknown function: js_encode`. Similar to fix in neosnippet (https://github.com/Shougo/neosnippet.vim/commit/d6333c191b478cbee869327c5e36bddc62ecfd5e), changed the func to `json_encode`. Tested locally looks good.

```
[neobundle] Error occurred while loading cache : Vim(return):E117: Unknown function: js_decode
Error detected while processing function neobundle#commands#save_cache[22]..neobundle#util#vim2json:
line    1:
E117: Unknown function: js_encode
E15: Invalid expression: has('patch-7.4.1498') ? js_encode(a:expr) : string(a:expr)
```